### PR TITLE
Bugfix: log levels in log.go + add regression test

### DIFF
--- a/log.go
+++ b/log.go
@@ -29,7 +29,7 @@ var LogLevel = LogError
 
 // Log a message through the newrelic package
 func Log(level LoggingLevel, format string, a ...interface{}) {
-	if level <= LogLevel {
+	if level >= LogLevel {
 		Logger.Printf(format, a...)
 	}
 }

--- a/log_test.go
+++ b/log_test.go
@@ -1,0 +1,28 @@
+package newrelic
+
+import (
+	"bytes"
+	l "log"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Log(t *testing.T) {
+	var b bytes.Buffer
+
+	Logger = l.New(&b, "", 0)
+	LogLevel = LogInfo
+
+	Log(LogError, "my error")
+	Log(LogInfo, "my info")
+
+	assert.Equal(t, "my error\nmy info\n", b.String())
+
+	LogLevel = LogError
+
+	Log(LogError, "my error 2")
+	Log(LogInfo, "my info 2")
+
+	assert.Equal(t, "my error\nmy info\nmy error 2\n", b.String())
+}


### PR DESCRIPTION
The log levels didn't work.

Nice work with the New Relic packages btw!
